### PR TITLE
Change build scripts to be independent from the working directory

### DIFF
--- a/build/build-iso.ps1
+++ b/build/build-iso.ps1
@@ -1,6 +1,17 @@
-﻿if (!((Split-Path -Path (Get-Location) -Leaf) -eq "build"))
+﻿# make sure we are in the correct directory
+$currentDir=Get-Location
+if ("$currentDir" -ne "$PSScriptRoot")
 {
-    Write-Output "This script must be run inside the build folder. Press ENTER to exit."; Read-Host; exit
+    try
+    {
+        pushd "$PSScriptRoot"
+        . $PSCommandPath
+    }
+    finally
+    {
+        popd
+    }
+    exit
 }
 
 if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))

--- a/build/build-iso.ps1
+++ b/build/build-iso.ps1
@@ -5,7 +5,7 @@ if ("$currentDir" -ne "$PSScriptRoot")
     try
     {
         pushd "$PSScriptRoot"
-        . $PSCommandPath
+        . $PSCommandPath $args
     }
     finally
     {

--- a/build/build-iso.sh
+++ b/build/build-iso.sh
@@ -2,7 +2,16 @@
 
 # Build Distro ISO using AUTO.ISO minimal auto-install as bootstrap to merge codebase, recompile system, and export ISO
 
-# Run this script inside build/ directory
+# make sure we are in the correct directory
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+SCRIPT_NAME=$(basename "$0")
+EXPECTED_DIR=$(realpath "$PWD")
+
+if test "${EXPECTED_DIR}" != "${SCRIPT_DIR}"
+then
+	( cd "$SCRIPT_DIR" || exit ; "./$SCRIPT_NAME" );
+	exit
+fi
 
 # Uncomment if you use doas instead of sudo
 #alias sudo=doas 

--- a/build/build-iso.sh
+++ b/build/build-iso.sh
@@ -9,7 +9,7 @@ EXPECTED_DIR=$(realpath "$PWD")
 
 if test "${EXPECTED_DIR}" != "${SCRIPT_DIR}"
 then
-	( cd "$SCRIPT_DIR" || exit ; "./$SCRIPT_NAME" );
+	( cd "$SCRIPT_DIR" || exit ; "./$SCRIPT_NAME" "$@" );
 	exit
 fi
 

--- a/build/sync.ps1
+++ b/build/sync.ps1
@@ -1,4 +1,20 @@
-﻿$choice = $args[0]
+﻿# make sure we are in the correct directory
+$currentDir=Get-Location
+if ("$currentDir" -ne "$PSScriptRoot")
+{
+    try
+    {
+        pushd "$PSScriptRoot"
+        . $PSCommandPath
+    }
+    finally
+    {
+        popd
+    }
+    exit
+}
+
+$choice = $args[0]
 
 function print_usage()
 {
@@ -17,11 +33,6 @@ if ($args.count -eq 0)
 if ($choice -ne 'repo' -and $choice -ne "vm")
 {
     print_usage
-}
-
-if (!((Split-Path -Path (Get-Location) -Leaf) -eq "build"))
-{
-    Write-Output "This script must be run inside the build folder. Press ENTER to exit."; Read-Host; exit
 }
 
 if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))

--- a/build/sync.ps1
+++ b/build/sync.ps1
@@ -5,7 +5,7 @@ if ("$currentDir" -ne "$PSScriptRoot")
     try
     {
         pushd "$PSScriptRoot"
-        . $PSCommandPath
+        . $PSCommandPath $args
     }
     finally
     {

--- a/build/sync.sh
+++ b/build/sync.sh
@@ -13,7 +13,7 @@ EXPECTED_DIR=$(realpath "$PWD")
 
 if test "${EXPECTED_DIR}" != "${SCRIPT_DIR}"
 then
-	( cd "$SCRIPT_DIR" || exit ; "./$SCRIPT_NAME" );
+	( cd "$SCRIPT_DIR" || exit ; "./$SCRIPT_NAME" "$@" );
 	exit
 fi
 

--- a/build/sync.sh
+++ b/build/sync.sh
@@ -1,11 +1,22 @@
 #!/bin/sh
 #
 # Sync VM <--> Repo.
-# Run this script inside build/ directory.
 #
 # On copying from virtual disk to src/, the directory is emptied before copy. Comment out "rm -rf ../src/*" to copy onto src.
 #
 #
+
+# make sure we are in the correct directory
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+SCRIPT_NAME=$(basename "$0")
+EXPECTED_DIR=$(realpath "$PWD")
+
+if test "${EXPECTED_DIR}" != "${SCRIPT_DIR}"
+then
+	( cd "$SCRIPT_DIR" || exit ; "./$SCRIPT_NAME" );
+	exit
+fi
+
 
 # Uncomment if you use doas instead of sudo
 #alias sudo=doas


### PR DESCRIPTION
This change allows running the build scripts from any directory, making it more robust and less likely for people to use it wrong.