### PR TITLE
Add QEMU_BIN_PATH variable

### DIFF
--- a/build/sync.sh
+++ b/build/sync.sh
@@ -11,6 +11,9 @@ SCRIPT_DIR=$(realpath "$(dirname "$0")")
 SCRIPT_NAME=$(basename "$0")
 EXPECTED_DIR=$(realpath "$PWD")
 
+# Change this if your default QEMU version does not work and you have installed a different version elsewhere.
+QEMU_BIN_PATH=$(dirname "$(which qemu-system-x86_64)")
+
 if test "${EXPECTED_DIR}" != "${SCRIPT_DIR}"
 then
 	( cd "$SCRIPT_DIR" || exit ; "./$SCRIPT_NAME" "$@" );
@@ -50,7 +53,7 @@ print_usage() {
 
 mount_vdisk() {
 	echo "Mounting virtual disk..."
-	sudo qemu-nbd -c /dev/nbd0 "$ZEALDISK"
+	sudo $QEMU_BIN_PATH/qemu-nbd -c /dev/nbd0 "$ZEALDISK"
 	sudo partprobe /dev/nbd0       
 	sudo mount /dev/nbd0p1 $TMPMOUNT
 }
@@ -59,7 +62,7 @@ umount_vdisk() {
 	echo "Unmounting virtual disk..."
 	sync
 	sudo umount $TMPMOUNT
-	sudo qemu-nbd -d /dev/nbd0
+	sudo $QEMU_BIN_PATH/qemu-nbd -d /dev/nbd0
 	sudo rm -rf $TMPMOUNT
 }
 


### PR DESCRIPTION
This makes it easier to change the path to which version of QEMU the scripts use.  On many of my Linux machines the default QEMU version does not work well with Zeal and I need to change the path everywhere in these scripts to point to a different version of QEMU I compile from source.