### PR TITLE
Skip partial updates when updating entire screen

### DIFF
--- a/src/System/Gr/GrScreen.ZC
+++ b/src/System/Gr/GrScreen.ZC
@@ -395,10 +395,16 @@ U0 GrUpdateScreen32()
 	while (src < size) //draw 2 pixels at a time
 		*dst++ = gr_palette[*src++ & 0xFF] | gr_palette[*src++ & 0xFF] << 32;
 
-	GrCalcScreenUpdates;
-
 	if (LBtr(&sys_semas[SEMA_FLUSH_VBE_IMAGE], 0))
+	{
 		MemCopy(text.fb_alias, text.raw_screen, text.buffer_size);
+		src -= GR_WIDTH * GR_HEIGHT; // Reset src ptr
+		MemCopy(gr.screen_cache, src, GR_WIDTH * GR_HEIGHT);
+	}
+	else
+	{
+		GrCalcScreenUpdates;
+	}
 }
 
 U0 GrUpdateScreen()


### PR DESCRIPTION
This change skips unnecessary work done by GrCalcScreenUpdates for the case when the entire screen is refreshed.

The original code calls GrCalcScreenUpdates even when a full screen refresh is going to happen which causes it to loop over the entire cache.  The original code causes text.fb_alias to be written by both GrCalcScreenUpdates and the MemCopy below it when it is only necessary to do just the MemCopy for both the frame buffer and the cache (we can skip the looping over the cache and checking for changes when we know we are just going to update everything).