### PR TITLE
Add support for user apps to capture raw mouse data and mouse support to Castle Frankenstein

### DIFF
--- a/src/Demo/Games/CastleFrankenstein.ZC
+++ b/src/Demo/Games/CastleFrankenstein.ZC
@@ -578,6 +578,29 @@ U0 RotateMan(F64 d)
 	}
 }
 
+CTask *mouse_task = NULL;
+CTask *game_task = Fs;
+F64 mouse_scale = 32.0;
+
+U0 MouseHandler()
+{
+	Bool button;
+	I64 x;
+	while (TRUE)
+	{
+		button = mouse_hard.raw_bttns[0];
+		x = mouse_hard.raw_data.x;
+		if (button || x!=0)
+			MouseRawReset; // Mark mouse data as consumed
+		if (button)
+			MessagePostWait(game_task,MESSAGE_KEY_DOWN_UP,CH_SPACE,0);
+		if (x != 0) {
+			man_é += (x/mouse_scale)/MICRO_STEPS;
+		}
+		Sleep(10);
+		}
+}
+
 U0 CastleFrankenstein()
 {
 	I64 sc;
@@ -616,6 +639,26 @@ U0 CastleFrankenstein()
 			{
 				case CH_SPACE:
 					Fire;
+					break;
+
+				case 'm':
+					if (!mouse_task) {
+						MouseRaw(TRUE);
+						mouse_task=Spawn(&MouseHandler,NULL);
+					}
+					else {
+						Kill(mouse_task);
+						mouse_task=NULL;
+						MouseRaw(FALSE);
+					}
+					break;
+
+				case '+':
+					mouse_scale *= 0.9;
+					break;
+
+				case '-':
+					mouse_scale *= 1.1;
 					break;
 
 				case '\n':
@@ -663,7 +706,11 @@ fs_done:
 	RegWrite("ZealOS/CastleFrankenstein", "F64 best_score=%5.4f;\n", best_score);
 }
 
+MouseRaw(TRUE);
+mouse_task=Spawn(&MouseHandler,NULL);
 CastleFrankenstein;
+if (mouse_task) Kill(mouse_task);
+MouseRaw(FALSE);
         &        
              
               

--- a/src/Kernel/KernelA.HH
+++ b/src/Kernel/KernelA.HH
@@ -3718,7 +3718,8 @@ public class CKbdStateGlobals
 public class CMouseHardStateGlobals
 {
 	CD3I64	 pos, 					//Position in pixels
-			 prescale;
+			 prescale,
+			 raw_data;
 	CD3 	 scale;
 	F64 	 speed;					//Output: How fast the user is moving it.
 	I64 	 timestamp,				//Output: TSCGet when event.
@@ -3726,6 +3727,8 @@ public class CMouseHardStateGlobals
 			 pkt_size;				//Private
 	CFifoU8	*fifo, *fifo2;			//Private
 	Bool	 bttns[5],
+			 raw_bttns[5],
+			 raw_mode,
 			 has_wheel,
 			 has_ext_bttns,
 			 enabled,

--- a/src/Kernel/KernelC.HH
+++ b/src/Kernel/KernelC.HH
@@ -503,6 +503,8 @@ extern			I64					 KbdMessagesQueue();
 public extern	U0					 KbdTypeMatic(U8 delay);
 extern			Bool				 MouseHardDriverInstall();
 public extern	Bool				 MouseHardEnable(Bool val=TRUE);
+public extern	Bool				 MouseRaw(Bool val);
+public extern	U0	    			 MouseRawReset(Bool val=TRUE);
 public extern	I64					 PressAKey();
 public extern	I64					 CharScan();
 public extern	Bool				 KeyScan(I64 *_ch=NULL, I64 *_scan_code=NULL, Bool echo=FALSE);

--- a/src/Kernel/SerialDev/Mouse.ZC
+++ b/src/Kernel/SerialDev/Mouse.ZC
@@ -44,6 +44,26 @@ U0 MouseUpdate(I64 x, I64 y, I64 z, Bool l, Bool r)
 	LBEqual(&kbd.scan_code, SCf_MS_R_DOWN, mouse.rb);
 }
 
+public U0 MouseRawReset()
+{
+	mouse_hard.raw_data.x=0;
+	mouse_hard.raw_data.y=0;
+	mouse_hard.raw_data.z=0;
+	mouse_hard.raw_bttns[0]=FALSE;
+	mouse_hard.raw_bttns[1]=FALSE;
+	mouse_hard.raw_bttns[2]=FALSE;
+	mouse_hard.raw_bttns[3]=FALSE;
+	mouse_hard.raw_bttns[4]=FALSE;
+}
+
+public Bool MouseRaw(Bool val)
+{ // Places mouse in "raw" mode, button presses will not go to windows manager when true
+	Bool old_val=mouse_hard.raw_mode;
+	mouse_hard.raw_mode=val;
+	mouse.show=!val;
+	return old_val;
+}
+
 U0 MouseSet(I64 x=I64_MAX, I64 y=I64_MAX, I64 z=I64_MAX, I64 l=I64_MAX, I64 r=I64_MAX)
 {//Note: Generates a message. See $LK,"MouseSet",A="FF:::/Demo/Games/Zing.ZC,MouseSet"$().
 	if (!(0 <= x < sys_framebuffer_width))
@@ -78,6 +98,7 @@ U0 MouseInit()
 	mouse.timestamp	 = TSCGet;
 	mouse.dbl_time	 = 0.175;
 	GridInit;
+	MouseRawReset;
 }
 
 U0 MouseHardPacketRead()
@@ -194,6 +215,7 @@ Bool MouseHardReset()
 		catch
 			Fs->catch_except = TRUE;
 
+	MouseRawReset;
 	return res;
 }
 
@@ -255,19 +277,14 @@ U0 MouseHardHandler()
 {
 	I64 i, dx, dy, dz;
 	U8  mouse_buf[4];
-
-	MouseHardSetPre;
+	if (!mouse_hard.raw_mode)
+		MouseHardSetPre;
 	for (i = 0; i < 4; i++)
 		mouse_buf[i] = 0;
 	for (i = 0; i < mouse_hard.pkt_size; i++)
 		if (!FifoU8Remove(mouse_hard.fifo2, &mouse_buf[i]))
 			mouse_buf[i] = 0;
 
-	mouse_hard.bttns[0] =  mouse_buf[0] & 1;
-	mouse_hard.bttns[1] = (mouse_buf[0] & 2)    >> 1;
-	mouse_hard.bttns[2] = (mouse_buf[0] & 4)    >> 2;
-	mouse_hard.bttns[3] = (mouse_buf[3] & 0x10) >> 4;
-	mouse_hard.bttns[4] = (mouse_buf[3] & 0x20) >> 5;
 	if (mouse_buf[0] & 0x10)
 		dx = mouse_buf[1]-256;
 	else
@@ -281,11 +298,30 @@ U0 MouseHardHandler()
 	else
 		dz = mouse_buf[3] & 7;
 
-	mouse_hard.prescale.x += dx;
-	mouse_hard.prescale.y += dy;
-	mouse_hard.prescale.z += dz;
-
-	MouseHardSetPost;
+	if (mouse_hard.raw_mode) {
+		// buttons / position data need to by consumed by app
+		// buttons stay down, positions keep accumulating until
+		// consumed by app and reset with MouseRawReset
+		mouse_hard.raw_bttns[0] |=  mouse_buf[0] & 1;
+		mouse_hard.raw_bttns[1] |= (mouse_buf[0] & 2)    >> 1;
+		mouse_hard.raw_bttns[2] |= (mouse_buf[0] & 4)    >> 2;
+		mouse_hard.raw_bttns[3] |= (mouse_buf[3] & 0x10) >> 4;
+		mouse_hard.raw_bttns[4] |= (mouse_buf[3] & 0x20) >> 5;
+		mouse_hard.raw_data.x += dx;
+		mouse_hard.raw_data.y += dy;
+		mouse_hard.raw_data.z += dz;
+	}
+	else {
+		mouse_hard.bttns[0] =  mouse_buf[0] & 1;
+		mouse_hard.bttns[1] = (mouse_buf[0] & 2)    >> 1;
+		mouse_hard.bttns[2] = (mouse_buf[0] & 4)    >> 2;
+		mouse_hard.bttns[3] = (mouse_buf[3] & 0x10) >> 4;
+		mouse_hard.bttns[4] = (mouse_buf[3] & 0x20) >> 5;
+		mouse_hard.prescale.x += dx;
+		mouse_hard.prescale.y += dy;
+		mouse_hard.prescale.z += dz;
+		MouseHardSetPost;
+	}
 }
 
 U0 MouseHardSet(I64 x, I64 y, I64 z, I64 l, I64 r)


### PR DESCRIPTION
This adds a new kernel function MouseRaw which can be used to switch between the mouse sending data to the window manager and the mouse accumulating raw data for a user application to process instead.

When MouseRaw(TRUE) is called it is up to a user application to read the raw data stored in mouse_hard and to clear the accumulated data with MouseRawReset once it has saved it.  If a cursor is desired, it is up to the user application to draw one.  No mouse data is sent to the window manager for other applications until MouseRaw(FALSE) is called.

This also adds mouse support code to CastleFrankenstein to demonstrate how to integrate this feature into a user application.  Now you can turn with the mouse and shoot with the left mouse button.  The m key toggles mouse capture.  The +/- keys increase and decrease the mouse sensitivity.