### PR TITLE
FlagsStrPrint() sanity check

### DIFF
--- a/src/Kernel/StrB.ZC
+++ b/src/Kernel/StrB.ZC
@@ -212,7 +212,7 @@ U8 *FlagsStrPrint(U8 *dst, U8 *list, I64 flags, Bool print_all=FALSE, I64 print_
 	I64 i = 0;
 
 	*dst = 0;
-	if (!print_all_length)
+	if (!print_all_length || print_all_length > 64)
 		print_all_length =  64;
 	while (i < print_all_length)
 	{


### PR DESCRIPTION
* By default, print_all_length is 64 and i counts from 0 to 63, covering all bits of flags
* Bt(&flags,64) probably doesn't make sense, so it might be safer to set a maximum cap value
* Negative values of print_all_length would result in not entering the loop
* I have not tested this
