### PR TITLE
Dont copy hidden files/folders to VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@
 *.o
 *.d
 /zealbooter/limine.h
-src/.*

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 *.o
 *.d
 /zealbooter/limine.h
+*.

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@
 *.o
 *.d
 /zealbooter/limine.h
-*.
+src/.*

--- a/build/sync.sh
+++ b/build/sync.sh
@@ -95,7 +95,8 @@ else
 		vm)
 			mount_vdisk
 			echo "Copying src to vdisk..."
-			sudo rsync -av --exclude='.*' ../src/ $TMPMOUNT/
+			cd ../src/
+			sudo find . \( ! -path './.*' -and ! -name '.*' \) -and ! -path '*/.*/*' -type f -exec cp --parents {} $TMPMOUNT/ \;
 			umount_vdisk
 			echo "Finished."
 			;;

--- a/build/sync.sh
+++ b/build/sync.sh
@@ -94,9 +94,17 @@ else
 			;;
 		vm)
 			mount_vdisk
-			echo "Copying src to vdisk..."
-			cd ../src/
-			sudo find . \( ! -path './.*' -and ! -name '.*' \) -and ! -path '*/.*/*' -type f -exec cp --parents {} $TMPMOUNT/ \;
+			case $2 in
+				--ignore-dots | --dots)
+					echo "Copying src to vdisk ignoring dotfiles and dotfolders..."
+					cd ../src/
+					sudo find . \( ! -path './.*' -and ! -name '.*' \) -and ! -path '*/.*/*' -type f -exec cp --parents {} $TMPMOUNT/ \;
+					;;
+				*)
+					echo "Copying entire src to vdisk..."
+					sudo cp -r ../src/* $TMPMOUNT
+					;;
+			esac
 			umount_vdisk
 			echo "Finished."
 			;;

--- a/build/sync.sh
+++ b/build/sync.sh
@@ -44,11 +44,11 @@ DOCS_DIR=
 TMPMOUNT=/tmp/zealtmp
 
 print_usage() {
-	echo "Usage: $0 [ repo | vm ]"
-	echo
-	echo " repo - overwrites src/ with virtual disk contents."
-	echo " vm - overwrites virtual disk with src/ contents."
-	echo
+	echo "Usage: $0 ( repo | vm ) [OPTION]"
+	echo "    repo             Overwrites src/ with virtual disk contents."
+	echo "    vm               Overwrites virtual disk with src/ contents."
+	echo "Options:"
+	echo "    --ignore-dots    Ignore dotfiles/dotfolders during synchronize."
 }
 
 mount_vdisk() {

--- a/build/sync.sh
+++ b/build/sync.sh
@@ -95,7 +95,7 @@ else
 		vm)
 			mount_vdisk
 			echo "Copying src to vdisk..."
-			sudo cp -r ../src/* $TMPMOUNT
+			sudo rsync -av --exclude='.*' ../src/ $TMPMOUNT/
 			umount_vdisk
 			echo "Finished."
 			;;


### PR DESCRIPTION
I've modified the sync script to ignore all `.*` files/folders.

The goal with this is to be able to have sub gits (not submodules) without copying the .git folders to the VM.

For example, with this I am able to clone the https://github.com/y4my4my4m/ZealAMP repository to my src/Home folder and work on it separately without having the .git folder and it's .gitignore file within the folder in the VM.