### PR TITLE
Remove "MagicISO" trademark.

### DIFF
--- a/src/Doc/GuideLines.DD
+++ b/src/Doc/GuideLines.DD
@@ -130,4 +130,4 @@ $FG$
 
 * RAX holds function return values, of course.
 $FG,8$
-* "MagicISO" is a trademark owned by MagicISO Corp.
+

--- a/src/Doc/GuideLines.DD
+++ b/src/Doc/GuideLines.DD
@@ -129,5 +129,5 @@ $FG$
 * No args are passed in registers.
 
 * RAX holds function return values, of course.
-$FG,8$
+
 


### PR DESCRIPTION
Maybe in the past the word "MagicISO" was used for something but I don't see it here. Therefore I suggest removing it.