### PR TITLE
allow single "+" or "-" prefix before number in Str2I64()

### DIFF
--- a/src/Kernel/StrScan.ZC
+++ b/src/Kernel/StrScan.ZC
@@ -13,18 +13,16 @@ I64 Str2I64(U8 *st, I64 radix=10, U8 **_end_ptr=NULL)
 	}
 	while (Bt(char_bmp_white_space, *st))
 		st++;
+	if (*st == '+')
+		st++;
+	else if (*st == '-')
+	{
+		neg = TRUE;
+		st++;
+	}
 	while (TRUE)
 		switch (*st)
 		{
-			case '-':
-				st++;
-				neg = !neg;
-				break;
-
-			case '+':
-				st++;
-				break;
-
 			case '0':
 				st++;
 				ch = ToUpper(*st);


### PR DESCRIPTION
* Make Str2I64() behave more like standard strtol() by taking the sign parsing code out of the loop
* Accepting number prefix of ++++ or ---- or ++-- doesn't make much sense; code relying on this is asking for trouble
