### PR TITLE
clean up unused FreeAll() function

### DIFF
--- a/src/Kernel/KernelC.HH
+++ b/src/Kernel/KernelC.HH
@@ -558,7 +558,6 @@ public extern				U8			*ReAlloc(    U8 *src, U64 size,         CTask *mem_task=NU
 public _extern _MHEAP_CTRL	CHeapCtrl	*MHeapCtrl(  U8 *src);
 public _extern _MSIZE		I64			 MSize(      U8 *src); 	//size of heap object
 public _extern _MSIZE2		I64			 MSize2(     U8 *src); //Internal size
-public extern				U0			 FreeAll(...); //Free all pointers passed
 
 #help_index "Memory/HeapCtrl"
 public extern U0		 HeapCtrlDel( CHeapCtrl *hc);

--- a/src/Kernel/Memory/MAllocFree.ZC
+++ b/src/Kernel/Memory/MAllocFree.ZC
@@ -504,11 +504,3 @@ U8 *SysStrNew(U8 *buf)
 {//Alloc copy of string in System task's heap.
 	return StrNew(buf, sys_task);
 }
-
-U0 FreeAll(...)
-{// Free all pointers passed
-	U64 cur_arg = 0;
-
-	while (argc--)
-		Free(argv[cur_arg++]);
-}


### PR DESCRIPTION
* FreeAll() could theoretically be used to reduce lines of code, but it would only be useful for adjacent Free()s and I didn't see any references to it in the tree
* Is it time to delete this?