### PR TITLE
TaskFocusNext(): reduce pointer updates

### DIFF
--- a/src/Kernel/Sched.ZC
+++ b/src/Kernel/Sched.ZC
@@ -37,10 +37,14 @@ $HL,1$*/
 
 U0 TaskFocusNext()
 {
-	CTask *task, *_task = sys_focus_task;
+	CTask *task, *_task;
 
-	sys_focus_task = NULL;
-	if (!_task)
+	if (sys_focus_task)
+	{
+		_task = sys_focus_task;
+		sys_focus_task = NULL;
+	}
+	else
 		_task = sys_task;
 	task = _task->next_task;
 	do


### PR DESCRIPTION
* Avoid setting _task and sys_focus_task to NULL if sys_focus_task is NULL
* Checking sys_focus_task directly is slightly clearer than checking !_task after copy
