### PR TITLE
Fix compiler bug

### DIFF
--- a/src/Compiler/OptPass012.ZC
+++ b/src/Compiler/OptPass012.ZC
@@ -170,16 +170,6 @@ in int<-->F64 conversions of function args.
 					tmpi->ic_flags |= ICF_USE_F64;
 				break;
 
-			case IC_COM:
-				if (tmpi1->ic_code == IC_IMM_I64)
-				{
-					tmpi->ic_data = ~tmpi1->ic_data;
-					tmpi->ic_code = IC_IMM_I64;
-					tmpi->ic_flags |= tmpi1->ic_flags;
-					OptSetNOP1(tmpi1);
-				}
-				tmpi_push->ic_class2 = cmp.internal_types[RT_I64];
-				break;
 			start:
 				case IC_NOT:
 					if (tmpc->raw_type == RT_F64)
@@ -1533,6 +1523,7 @@ in int<-->F64 conversions of function args.
 			case IC_NOBOUND_SWITCH:
 			case IC_SWITCH:
 			case IC_ASM:
+			case IC_COM:
 				break;
 
 			default:


### PR DESCRIPTION
Test case:
I64 Bug(I64 x)
{
  x&=~1;
  return x;
}

Bug(-200) should produce -200, but doesn't without this fix.