### PR TITLE
Tcp fix

### DIFF
--- a/src/Home/Net/Protocols/TCP/TCP.HH
+++ b/src/Home/Net/Protocols/TCP/TCP.HH
@@ -6,7 +6,10 @@
 #define TCP_RTO_MIN		0.2
 #define TCP_RTO_MAX		10
 
-#define TCP_WINDOW_SIZE	8192
+#define TCP_WINDOW_SIZE	8192 // Should not be static. For now it's okay
+
+U16 RECEIVE_WINDOW; // gets host window size. It is not static.
+U16 SEND_WINDOW; // gets receive window size from host, then adjust accordingly. 
 
 #define TCP_MSS			536 // Max Segment Size default
 
@@ -24,7 +27,7 @@
 #define TCP_STATE_LAST_ACK		9
 #define TCP_STATE_TIME_WAIT		10
 
-// TCP header flags. Test with Bt(), e.g. Bt(&flags, TCPf_RST)
+// TCP header flags. Order of Operation matters. Test with Bt(), e.g. Bt(&flags, TCPf_RST)
 #define TCPf_FIN	0
 #define TCPf_SYN	1
 #define TCPf_RST	2

--- a/src/Home/Net/Protocols/TCP/TCP.ZC
+++ b/src/Home/Net/Protocols/TCP/TCP.ZC
@@ -101,7 +101,7 @@ I64 TCPPacketAllocate(U8 **frame_out,
 	header->ack_num				= EndianU32(ack_num);
 	header->data_offset			= (sizeof(CTCPHeader) / 4) << 4; // ???
 	header->flags				= flags;
-	header->window_size			= EndianU16(TCP_WINDOW_SIZE / 2);// TODO: What is window size supposed to be ?
+	header->window_size			= EndianU16(TCP_WINDOW_SIZE);// Window Size allocation data. Adjusted based on receive window. 
 	header->checksum			= 0;
 	header->urgent_pointer		= 0;
 
@@ -647,8 +647,8 @@ CTCPSocket TCPSocket(U16 domain=AF_UNSPEC)
 	QueueInit(accept_queue); // init pending connection queue
 	tcp_socket->accept_queue = accept_queue;
 
-	tcp_socket->receive_buffer_size = TCP_WINDOW_SIZE;
-	tcp_socket->receive_buffer = CAlloc(TCP_WINDOW_SIZE);
+	tcp_socket->receive_buffer_size = RECEIVE_WINDOW;
+	tcp_socket->receive_buffer = CAlloc(RECEIVE_WINDOW);
 
 	tcp_socket->max_segment_size = TCP_MSS;
 
@@ -1057,7 +1057,7 @@ I64 TCPSocketConnect(CTCPSocket *tcp_socket, CSocketAddressStorage *address)
 	}
 
 	tcp_socket->connection_time = tS;
-	tcp_socket->receive_window	= TCP_WINDOW_SIZE;
+	tcp_socket->receive_window	= RECEIVE_WINDOW;
 
 	tcp_socket->state = TCP_STATE_SYN_SENT;
 	TCPSendFlags(tcp_socket, TCPF_SYN);
@@ -1165,7 +1165,7 @@ CTCPSocket *TCPSocketAccept(CTCPSocket *tcp_socket)
 
 	new_socket->next_recv_seq_num	= ++pending->segment_seq_num;
 	new_socket->connection_time		= tS;
-	new_socket->receive_window		= TCP_WINDOW_SIZE;
+	new_socket->receive_window		= RECEIVE_WINDOW;
 	new_socket->timeout				= tcp_socket->timeout;
 
 	temp_addr = &tcp_socket->source_address;

--- a/src/Home/Net/Utilities/Net.HH
+++ b/src/Home/Net/Utilities/Net.HH
@@ -8,9 +8,11 @@
 #define FCS_LENGTH					4
 
 /*	Ethernet Frame Size.
-	Linux uses 1544, OSDev and Shrine use 1548. Based on IEEE 802.3as, max frame size was agreed upon as 2000 bytes. */
-#define ETHERNET_FRAME_SIZE	2000
-
+	Based on IEEE 802.3 layer 1 Ethernet Max Frame is 1542 according to wiki. 72-1530 frame octet + 12 IPG octet
+	Default: 1538 | Vlan: 1542 | Jumbo: 9038 | JumboVlan: 9042 */
+#define ETHERNET_FRAME_SIZE     1542
+  
+// Max PayLoad standard: 1500 | Jumbo: 9000 for Gignet (fiber)
 #define ETHERNET_v2_MTU 1500
 
 #define HTYPE_ETHERNET	1


### PR DESCRIPTION
!!WIP!! 

TLDR;  reduced packet loss, reduced fragments, and reduced lost connection which may noticed a slightly increased speeds, and snappy response. 

The window size is the amount of data that the receiving host is capable of accepting at any given time. The sender should limit the amount of data it sends based on the size of the window advertised by the receiver.

Receive window size isn't being recorded but instead we got a static client (sender) window size. Every time it communicate to the server, it negligence their window size. It say, "I don't care about your window size, mine is better." Basically it override host and thus it get corrupted part of the data. Telnet ANSI render gets messed up because it negligent the host data. This almost fixes it. I think once this get this panned out, there will be no issues with telnet client as well as losing connection to host when downloading files  (I think there is a missing section that holds 

Like for example.. 
Look at TCP.ZC LINE 1086
`    tcp_socket->receive_window      = TCP_WINDOW_SIZE; `

Why are we getting client side window side when we are SUPPOSE to GET host window_size.  Whatever we get from server gets override by client side static black magic number.   

Furthermore, the biggest problem with this current code is that it tries to combine sender/receive information. 

TCP.ZC LINE 67  
`    TCPPacketAllocate {.....};`

This is a great example of getting confused. It combines send/receive.  Those section needs rework.  

Lastly, Endian... 

Network bytes are BIG Endian. whatever it send out,  it has to swap to B.E. It is coded in, that's good. However, I noticed that we're getting L.E. from the host which is odd. This could mess up telnet ANSI. I'm not sure. That'll be a different issue/pull request. This needs a study case after TCP send/receive is resolved.
