### PR TITLE
Fixed the curl command for limine protocol header

### DIFF
--- a/zealbooter/GNUmakefile
+++ b/zealbooter/GNUmakefile
@@ -94,7 +94,7 @@ all: bin/$(OUTPUT)
 -include $(HEADER_DEPS)
 
 src/limine.h:
-	curl -Lo $@ https://github.com/limine-bootloader/limine/raw/trunk/limine.h || cp ../build/limine/limine.h src/limine.h || echo "ERROR"
+	curl -Lo $@ https://raw.githubusercontent.com/limine-bootloader/limine-protocol/refs/heads/trunk/include/limine.h || cp ../build/limine/limine.h src/limine.h || echo "ERROR"
 
 # Link rules for the final executable.
 bin/$(OUTPUT): GNUmakefile linker.ld $(OBJ)


### PR DESCRIPTION
Limine bootloader project changed the source of the protocol header file into another separate repo. I just updated the location in the makefile